### PR TITLE
design: dropdown 생성 위치 부모 요소 기준 왼쪽으로 변경

### DIFF
--- a/src/components/DropDown/Dropdown.tsx
+++ b/src/components/DropDown/Dropdown.tsx
@@ -8,11 +8,7 @@ const variantClassMap = {
   small: 'min-w-[101px] text-sm',
 } as const;
 
-const Dropdown = ({
-  variant,
-  options,
-  children,
-}: DropdownProps) => {
+const Dropdown = ({ variant, options, children }: DropdownProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
@@ -41,7 +37,7 @@ const Dropdown = ({
       {isOpen && (
         <ul
           role="listbox"
-          className={`absolute left-0 top-full mt-5 rounded-sm border border-[hsl(var(--gray-300))] bg-white shadow-[0_16px_32px_rgba(0,0,0,0.1)] ${variantClassMap[variant]}`}
+          className={`absolute right-0 top-full mt-5 rounded-sm border border-[hsl(var(--gray-300))] bg-white shadow-[0_16px_32px_rgba(0,0,0,0.1)] ${variantClassMap[variant]}`}
         >
           {options.map((option) => (
             <li key={option.label} className="px-[4px] py-[3px]">


### PR DESCRIPTION
## #️⃣연관된 이슈

> #15 

## 📝작업 내용

> dropdown이 부모 요소 기준, 왼쪽으로 생성됩니다.

### 스크린샷 (선택)

<img width="174" height="193" alt="image" src="https://github.com/user-attachments/assets/0d95625f-70f7-4fa9-a04c-ff1400960b94" />

