### PR TITLE
refactor: 공통 레이아웃 리팩토링

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,9 +18,7 @@ export default function RootLayout({
       <body className="min-h-screen flex flex-col bg-white">
         <ModalProvider>
           <Header isLogin={false} HeaderBg={false} />
-          <main className="w-full max-w-[1140px] mx-auto px-4 md:px-8">
-            {children}
-          </main>
+          <main>{children}</main>
         </ModalProvider>
       </body>
     </html>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 @config "../../tailwind.config.ts";
 
 :root {
@@ -19,5 +19,11 @@
   html {
     word-break: keep-all;
     @apply font-sans;
+  }
+}
+
+@layer components {
+  .container-layout {
+    @apply w-full max-w-[1204px] mx-auto px-4 md:px-8;
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#102

## 📝작업 내용

- 공통 레이아웃 스타일을 container-layout 클래스로 분리

background 색상이 꽉 차는 레이아웃 때문에 수정하게 되었습니다.
필요한 부분에 `className='container-layout'`을 적용하면 됩니다.