### PR TITLE
refactor: API URL 환경 변수 설정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,9 @@ import '../styles/globals.css';
 import Header from '@/components/Header/Header';
 
 export const metadata: Metadata = {
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000',
+  ),
   title: 'WINE',
   description: '현명한 와인 구매를 위한 리뷰 플랫폼',
   icons: {

--- a/src/lib/api/axios.ts
+++ b/src/lib/api/axios.ts
@@ -1,8 +1,10 @@
 import axios from 'axios';
 import { setupInterceptors } from './interceptors';
 
+const baseURL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
 export const instance = axios.create({
-  baseURL: 'https://winereview-api.vercel.app/23-3',
+  baseURL: baseURL,
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#113

## 📝 작업 내용

- API URL 환경 변수 설정
- 메타데이터 기준 URL 환경 변수 설정

## 💻 사용 방법

루트 디렉토리에 `.env.local` 파일 생성 후 해당 내용 작성
```
NEXT_PUBLIC_SITE_URL=https://wine-fe23-3.vercel.app
NEXT_PUBLIC_API_BASE_URL=https://winereview-api.vercel.app/23-3
```

추후 vercel에 재 배포할 때 vercel에서도 설정 필요